### PR TITLE
Update index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -138,7 +138,11 @@ function shutdown (cb) {
   }
 
   publish()
-  connection.disconnect()
+  
+  if(connection){
+    connection.disconnect()
+  }
+  
   cb()
 }
 


### PR DESCRIPTION
Add double check before connection disconnect.

I run log4js-node-ampq in my server, and when i try to shutdown process I get this error:

TypeError: undefined is not a function
   at process.shutdown (C:\nodeServices\ORM\node_modules\log4js-node-amqp\lib\index.js:141:14)
   at process.g (events.js:199:16)
   at process.emit (events.js:107:17)
   at process.exit (node.js:600:17)
   at StatWatcher.<anonymous> (C:\nodeServices\ORM\socketio_server.js:25:13)
   at StatWatcher.emit (events.js:110:17)
   at StatWatcher._handle.onchange (fs.js:1226:10)
C:\nodeServices\ORM\node_modules\log4js-node-amqp\lib\index.js:141
 connection.disconnect()

I see you check that "connection" is defined in line 136, 
but for some reason, after the publish in line 140, 
connection is undefined,
so I add another check after publish function to be sure that "connection" is defined,
before we call disconnect.
